### PR TITLE
Add Git information to version command

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -10,7 +10,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd := cobra.Command{
 		Use:     "verless",
 		Short:   `A simple and lightweight Static Site Generator.`,
-		Version: config.Version,
+		Version: config.GitTag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/config/global.go
+++ b/config/global.go
@@ -1,8 +1,10 @@
 package config
 
 var (
-	// Version is injected when building a new release.
-	Version string = "UNDEFINED"
+	// GitTag is injected when building a new release.
+	GitTag string = "UNDEFINED"
+	// GitCommit stores the latest Git commit.
+	GitCommit string = "UNKNOWN"
 )
 
 const (

--- a/core/version.go
+++ b/core/version.go
@@ -6,6 +6,13 @@ import (
 	"github.com/verless/verless/config"
 )
 
+var (
+	// format is the default format string for printing the version.
+	format = `verless version %s
+Git tag: %s
+Git commit: %s`
+)
+
 // VersionOptions represents options for the version command.
 type VersionOptions struct {
 	// Quiet only prints the plain version number.
@@ -14,14 +21,10 @@ type VersionOptions struct {
 
 // RunVersion prints verless version information.
 func RunVersion(options VersionOptions) error {
-	var format string
-
 	if options.Quiet {
-		format = "%s"
-	} else {
-		format = "verless version %s"
+		fmt.Printf("%s", config.GitTag)
 	}
 
-	fmt.Printf(format, config.Version)
+	fmt.Printf(format, config.GitTag, config.GitTag, config.GitCommit)
 	return nil
 }

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -16,17 +16,19 @@ def main():
         "darwin": ["386", "arm"]
     }
 
+    git_data = get_git_data()
+
     for go_os in operating_systems:
         for go_arch in architectures:
 
             if go_os in exclusions and go_arch in exclusions[go_os]:
                 continue
 
-            build(go_os, go_arch)
+            build(go_os, go_arch, git_data)
             package(go_os, go_arch)
 
 
-def build(go_os, go_arch):
+def build(go_os, go_arch, git_data):
     """Build the verless binary for the given operating system and
     the given platform.
 
@@ -41,8 +43,8 @@ def build(go_os, go_arch):
     env["GOOS"] = go_os
     env["GOARCH"] = go_arch
 
-    tag = env["CIRCLE_TAG"]
-    ld_flags = "-X github.com/verless/verless/config.Version={0}".format(tag)
+    ld_flags = "-X github.com/verless/verless/config.GitTag={0} -X github.com/verless/verless/config.GitCommit={1}" \
+        .format(git_data["tag"], git_data["commit"])
 
     subprocess.Popen(
         ["go", "build", "-v", "-ldflags", ld_flags, "-o", target, "cmd/verless/main.go"],
@@ -61,6 +63,25 @@ def package(go_os, go_arch):
     src = "target/{0}-{1}/".format(go_os, go_arch)
 
     shutil.make_archive(dest, ext, src)
+
+
+def get_git_data():
+    """
+    Read the latest annotated Git tag without revision number as
+    well as the short hash of the latest Git commit.
+
+    The data is stored and returned as a dictionary.
+    """
+    git_tag = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])
+    git_tag = git_tag.decode("utf-8")
+
+    git_commit = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+    git_commit = git_commit.decode("utf-8")
+
+    return {
+        "tag": git_tag,
+        "commit": git_commit,
+    }
 
 
 main()


### PR DESCRIPTION
Fixes #63.

This change will produce the following behavior:

```shell script
$ verless version
  verless version v0.1.2
  Git tag: v0.1.2
  Git commit: e51294d
```