### PR TITLE
Directly use site.CreateNode

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -31,23 +31,13 @@ func (b *builder) RegisterPage(page model.Page) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	var (
-		n   *model.Node
-		err error
-	)
-
-	// ToDo: Just use CreateRoute here without the if condition.
-	if page.Route != "/" {
-		n, err = b.site.CreateNode(page.Route)
-		if err != nil {
-			return err
-		}
-	} else {
-		n = &b.site.Root
+	node, err := b.site.CreateNode(page.Route)
+	if err != nil {
+		return err
 	}
 
-	n.Pages = append(n.Pages, page)
-	n.IndexPage.Pages = append(n.IndexPage.Pages, &n.Pages[len(n.Pages)-1])
+	node.Pages = append(node.Pages, page)
+	node.IndexPage.Pages = append(node.IndexPage.Pages, &node.Pages[len(node.Pages)-1])
 
 	return nil
 }


### PR DESCRIPTION
The old implementation decided itself whether to create a new route or use the root route. This isn't actually the builder's job, and since #75, `CreateRoute` already handles this case on its own:

https://github.com/verless/verless/blob/c442b514aa18e382963ab8acb753bf67c238dc6f/model/site.go#L67:L69

So we can remove this from the builder.