### PR TITLE
fix: Wait for first build when serving

### DIFF
--- a/core/serve.go
+++ b/core/serve.go
@@ -99,15 +99,15 @@ func RunServe(path string, options ServeOptions) error {
 			}
 		}()
 
-		// Trigger an initial rebuild.
+		// Trigger and wait for the initial rebuild.
 		rebuildCh <- path
+		<-firstBuildFinished
 
 		// Stop rebuilding goroutine if not watching.
 		if !options.Watch {
 			done <- true
 			close(done)
 		}
-		<-firstBuildFinished
 	}
 
 	// If the target folder doesn't exist, return an error.


### PR DESCRIPTION
This fixes an folder not found error if the target doesn't exist when running serve as the first build is not finished when starting to serve the target.

This pr simply waits for the first build to be finished.