### PR TITLE
Pre-build commands

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Types   map[string]*model.Type
 	Build   struct {
 		Overwrite bool
+		Before    []string
 	}
 }
 

--- a/core/build.go
+++ b/core/build.go
@@ -90,8 +90,7 @@ func RunBuild(fs afero.Fs, path string, options BuildOptions, cfg config.Config)
 		cmd.Dir = ctx.Path
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
-		err := cmd.Run()
-		if err != nil {
+		if err := cmd.Run(); err != nil {
 			return err
 		}
 	}

--- a/core/build.go
+++ b/core/build.go
@@ -3,7 +3,9 @@ package core
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -80,6 +82,18 @@ func RunBuild(fs afero.Fs, path string, options BuildOptions, cfg config.Config)
 			return fmt.Errorf("plugin %s not found", key)
 		}
 		ctx.Plugins = append(ctx.Plugins, plugins[key]())
+	}
+
+	for _, beforeHook := range cfg.Build.Before {
+		cmdParts := strings.Split(beforeHook, " ")
+		cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+		cmd.Dir = ctx.Path
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		err := cmd.Run()
+		if err != nil {
+			return err
+		}
 	}
 
 	errs := build.Run(ctx)

--- a/core/serve.go
+++ b/core/serve.go
@@ -3,6 +3,7 @@ package core
 import (
 	"log"
 	"net"
+	"path/filepath"
 	"sync"
 
 	"github.com/spf13/afero"
@@ -50,10 +51,13 @@ func RunServe(path string, options ServeOptions) error {
 	// Only watch if needed.
 	if options.Watch {
 		if err := watch.Run(watch.Context{
-			IgnorePath: targetFiles,
-			Path:       path,
-			ChangedCh:  rebuildCh,
-			StopCh:     done,
+			IgnorePaths: []string{
+				targetFiles,
+				filepath.Join(path, "static/generated"),
+			},
+			Path:      path,
+			ChangedCh: rebuildCh,
+			StopCh:    done,
 		}); err != nil {
 			return err
 		}

--- a/core/watch/watch.go
+++ b/core/watch/watch.go
@@ -3,6 +3,7 @@
 package watch
 
 import (
+	"fmt"
 	"log"
 	"path/filepath"
 	"strings"
@@ -13,10 +14,10 @@ import (
 
 // Context provides all components required for serving an already built project.
 type Context struct {
-	Path       string
-	IgnorePath string
-	ChangedCh  chan<- string
-	StopCh     <-chan bool
+	Path        string
+	IgnorePaths []string
+	ChangedCh   chan<- string
+	StopCh      <-chan bool
 }
 
 // Run watches a verless project for changes and writes the changed
@@ -28,6 +29,7 @@ func Run(ctx Context) error {
 	w.FilterOps(watcher.Write)
 
 	go func() {
+	watcherLoop:
 		for {
 
 			select {
@@ -38,9 +40,18 @@ func Run(ctx Context) error {
 				if filepath.Ext(event.Path) == "" {
 					continue
 				}
-				if strings.HasPrefix(event.Path, ctx.IgnorePath) {
-					continue
+
+				for _, ignorePath := range ctx.IgnorePaths {
+					p, err := filepath.Abs(ignorePath)
+					if err != nil {
+						fmt.Errorf("%v", err)
+						continue
+					}
+					if strings.HasPrefix(event.Path, p) {
+						continue watcherLoop
+					}
 				}
+
 				ctx.ChangedCh <- event.Path
 
 			case err, ok := <-w.Error:
@@ -61,7 +72,7 @@ func Run(ctx Context) error {
 		return err
 	}
 
-	if err := w.Ignore(ctx.IgnorePath); err != nil {
+	if err := w.Ignore(ctx.IgnorePaths...); err != nil {
 		return err
 	}
 

--- a/core/watch/watch.go
+++ b/core/watch/watch.go
@@ -3,7 +3,6 @@
 package watch
 
 import (
-	"fmt"
 	"log"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,7 @@ func Run(ctx Context) error {
 				for _, ignorePath := range ctx.IgnorePaths {
 					p, err := filepath.Abs(ignorePath)
 					if err != nil {
-						fmt.Errorf("%v", err)
+						log.Println(err)
 						continue
 					}
 					if strings.HasPrefix(event.Path, p) {


### PR DESCRIPTION
This PR implements commands which run directly before building the files.

However there are some things to discuss:
- multi-os compatibility (ability to provide different commands for different OS, and one command as catch-all)
```yaml
build:
  before:
    linux:
      - sassc css/style.scss css/style.css
    windows:
      - ...
    default:
      - ...
```
- support themes somehow 
 --> For example using {theme} in the path and replace it by the current theme
 --> or even add the ability to add commands to each theme separately. Then you could add sass command to one theme only.
I would prefer the last option.
For example with an extra theme.yml in the theme folder
```yaml
# theme.yml is your theme configuration.
version: 1
build:
  before:
    - sassc css/style.scss css/style.css
```
- problem with watch: if for example sass creates/updates a style.css the watcher triggers, which triggers a rebuild, which triggers sass, which triggers the watcher...
--> add ability to exclude certain files from the watcher.
--> or allow folders like `generated/*` and `themes/default/generated/*` which are ignored by the watcher and where you can put the generated files and then just use `<link rel="stylesheet" type="text/css" href="/generated/css/style.css" />` in the html templates.

Closes #158