### PR TITLE
feature: verless create file command

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -37,7 +37,7 @@ func newCreateFile() *cobra.Command {
 		},
 	}
 
-	createFileCmd.Flags().StringVar(&options.Project, "project", ".", `project path to create file in.`)
+	createFileCmd.Flags().StringVarP(&options.Project, "project", "p", ".", `project path to create file in.`)
 
 	return &createFileCmd
 }

--- a/cli/create.go
+++ b/cli/create.go
@@ -17,8 +17,25 @@ func newCreateCmd() *cobra.Command {
 
 	createCmd.AddCommand(newCreateProjectCmd())
 	createCmd.AddCommand(newCreateThemeCmd())
+	createCmd.AddCommand(newCreateFile())
 
 	return &createCmd
+}
+
+// newCreateFile creates the `verless create file` command
+func newCreateFile() *cobra.Command {
+
+	createFileCmd := cobra.Command{
+		Use:   "file NAME",
+		Short: `Create a new content file`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			return core.CreateFile(path)
+		},
+	}
+
+	return &createFileCmd
 }
 
 // newCreateProjectCmd creates the `verless create project` command.

--- a/cli/create.go
+++ b/cli/create.go
@@ -24,16 +24,20 @@ func newCreateCmd() *cobra.Command {
 
 // newCreateFile creates the `verless create file` command
 func newCreateFile() *cobra.Command {
-
+	var (
+		options core.CreateFileOptions
+	)
 	createFileCmd := cobra.Command{
 		Use:   "file NAME",
 		Short: `Create a new content file`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := args[0]
-			return core.CreateFile(path)
+			return core.CreateFile(path, options)
 		},
 	}
+
+	createFileCmd.Flags().StringVar(&options.Project, "project", ".", `project path to create file in.`)
 
 	return &createFileCmd
 }

--- a/core/create.go
+++ b/core/create.go
@@ -139,13 +139,7 @@ func CreateFile(filePath string, options CreateFileOptions) error {
 		return ErrProjectNotExists
 	}
 
-	var contentPath string
-	if options.Project != "." {
-		contentPath = filepath.Join(options.Project, ContentDir, filePath)
-
-	} else {
-		contentPath = filepath.Join(ContentDir, filePath)
-	}
+	contentPath := filepath.Join(options.Project, ContentDir, filePath)
 
 	if _, err := os.Stat(path.Dir(contentPath)); os.IsNotExist(err) {
 		return ErrNoSuchDirExists

--- a/core/create.go
+++ b/core/create.go
@@ -2,9 +2,12 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/afero"
 	. "github.com/verless/verless/config"
@@ -20,6 +23,9 @@ var (
 
 	// ErrThemeExists states that the specified theme already exists.
 	ErrThemeExists = errors.New("theme already exists, remove it first")
+
+	// ErrNoSuchDirExists states that the specified directory doesn't exist
+	ErrNoSuchDirExists = errors.New("no such directory exist, create it first")
 )
 
 // CreateProjectOptions represents options for creating a project.
@@ -116,6 +122,31 @@ func CreateTheme(path, name string) error {
 	}
 
 	return createFiles(files)
+}
+
+// CreateFile creates a file with specified path under content directory.
+func CreateFile(filePath string) error {
+
+	contentPath := filepath.Join(ContentDir, filePath)
+
+	if _, err := os.Stat(path.Dir(contentPath)); os.IsNotExist(err) {
+		return ErrNoSuchDirExists
+	}
+	defaultContentTemplate :=
+		`---
+Title:
+Description:
+Date: %s
+---
+`
+
+	content := fmt.Sprintf(defaultContentTemplate, time.Now().Format("2006-01-02"))
+	if err := ioutil.WriteFile(contentPath, []byte(content), 0755); err != nil {
+		return err
+	}
+
+	return nil
+
 }
 
 func createFiles(files map[string][]byte) error {

--- a/core/create.go
+++ b/core/create.go
@@ -24,6 +24,9 @@ var (
 	// ErrThemeExists states that the specified theme already exists.
 	ErrThemeExists = errors.New("theme already exists, remove it first")
 
+	// ErrFileExist states that the specified file already exists.
+	ErrFileExists = errors.New("file already exists.")
+
 	// ErrNoSuchDirExists states that the specified directory doesn't exist
 	ErrNoSuchDirExists = errors.New("no such directory exist, create it first")
 )
@@ -31,6 +34,11 @@ var (
 // CreateProjectOptions represents options for creating a project.
 type CreateProjectOptions struct {
 	Overwrite bool
+}
+
+// CreateFileOptions represents project path for creating file.
+type CreateFileOptions struct {
+	Project string
 }
 
 // CreateProject creates a new verless project. If the specified project
@@ -125,13 +133,28 @@ func CreateTheme(path, name string) error {
 }
 
 // CreateFile creates a file with specified path under content directory.
-func CreateFile(filePath string) error {
+func CreateFile(filePath string, options CreateFileOptions) error {
 
-	contentPath := filepath.Join(ContentDir, filePath)
+	if _, err := os.Stat(options.Project); os.IsNotExist(err) {
+		return ErrProjectNotExists
+	}
+
+	var contentPath string
+	if options.Project != "." {
+		contentPath = filepath.Join(options.Project, ContentDir, filePath)
+
+	} else {
+		contentPath = filepath.Join(ContentDir, filePath)
+	}
 
 	if _, err := os.Stat(path.Dir(contentPath)); os.IsNotExist(err) {
 		return ErrNoSuchDirExists
 	}
+
+	if _, err := os.Stat(contentPath); !os.IsNotExist(err) {
+		return ErrFileExists
+	}
+
 	defaultContentTemplate :=
 		`---
 Title:

--- a/core/create.go
+++ b/core/create.go
@@ -25,10 +25,7 @@ var (
 	ErrThemeExists = errors.New("theme already exists, remove it first")
 
 	// ErrFileExist states that the specified file already exists.
-	ErrFileExists = errors.New("file already exists.")
-
-	// ErrNoSuchDirExists states that the specified directory doesn't exist
-	ErrNoSuchDirExists = errors.New("no such directory exist, create it first")
+	ErrFileExists = errors.New("file already exists")
 )
 
 // CreateProjectOptions represents options for creating a project.
@@ -73,7 +70,7 @@ func CreateProject(path string, options CreateProjectOptions) error {
 			return nil
 		})
 		if err != nil {
-			return errors.New("Cannot remove existing files from current directory.")
+			return errors.New("Cannot remove existing files from current directory")
 		}
 	}
 
@@ -142,7 +139,7 @@ func CreateFile(filePath string, options CreateFileOptions) error {
 	contentPath := filepath.Join(options.Project, ContentDir, filePath)
 
 	if _, err := os.Stat(path.Dir(contentPath)); os.IsNotExist(err) {
-		return ErrNoSuchDirExists
+		return fmt.Errorf("no such dir %s exist, create it first", path.Dir(contentPath))
 	}
 
 	if _, err := os.Stat(contentPath); !os.IsNotExist(err) {


### PR DESCRIPTION
for issue #65 

We can also pass path to command for example 
`verless create file blog/file.md`
Will check if `blog` directory exist in content directory and if it exist, it will create a file in path `content/blog`

I hope you like this functionality.