### PR TITLE
fix: replace /js and /css directoreis with single top level directory

### DIFF
--- a/config/global.go
+++ b/config/global.go
@@ -31,6 +31,9 @@ const (
 	// JsDir is the directory for JavaScript files.
 	JsDir string = "js"
 
+	// AssetsDir is the directory containing CSS and JavaScript files.
+	AssetsDir string = "assets"
+
 	// DefaultTheme is the name of the default theme.
 	DefaultTheme string = "default"
 

--- a/core/create.go
+++ b/core/create.go
@@ -92,7 +92,7 @@ func CreateProject(path string, options CreateProjectOptions) error {
 		filepath.Join(path, ".gitignore"):                                 defaultGitignore,
 		filepath.Join(theme.TemplateDir(path, DefaultTheme), ListPageTpl): defaultTpl,
 		filepath.Join(theme.TemplateDir(path, DefaultTheme), PageTpl):     {},
-		filepath.Join(theme.CssDir(path, DefaultTheme), "style.css"):      defaultCss,
+		filepath.Join(theme.AssetsDir(path, DefaultTheme), "style.css"):   defaultCss,
 	}
 
 	return createFiles(files)

--- a/core/defaults.go
+++ b/core/defaults.go
@@ -14,7 +14,7 @@ build:
 <html lang="en">
     <head>
         <title>{{.Meta.Title}}</title>
-        <link rel="stylesheet" href="/css/style.css" />
+        <link rel="stylesheet" href="/assets/style.css" />
     </head>
     <body>
         <main>

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -38,6 +38,11 @@ func JsDir(path, name string) string {
 	return filepath.Join(Dir(path, name), config.JsDir)
 }
 
+// AssetsDir returns the assets directory path of a given theme.
+func AssetsDir(path, name string) string {
+	return filepath.Join(Dir(path, name), config.AssetsDir)
+}
+
 // GeneratedDir returns the generated directory path of a given theme.
 func GeneratedDir(path, name string) string {
 	return filepath.Join(Dir(path, name), config.GeneratedDir)

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -170,6 +170,11 @@ func (w *writer) copyDirs() error {
 			fileOnly: true,
 		},
 		{
+			src:      theme.AssetsDir(w.ctx.Path, w.ctx.Theme),
+			dest:     filepath.Join(w.ctx.OutputDir, config.AssetsDir),
+			fileOnly: true,
+		},
+		{
 			src:      theme.GeneratedDir(w.ctx.Path, w.ctx.Theme),
 			dest:     filepath.Join(w.ctx.OutputDir, config.GeneratedDir),
 			fileOnly: false,


### PR DESCRIPTION
fix for issue #169 