### PR TITLE
fix: panic when list page's route is empty

### DIFF
--- a/writer/writer.go
+++ b/writer/writer.go
@@ -65,6 +65,10 @@ func (w *writer) Write(site model.Site) error {
 
 		lp := node.(*model.Node).ListPage
 
+		if lp.Route == "" {
+			panic("route must not be empty")
+		}
+
 		return w.writeListPage(lp.Route, listPage{
 			Meta:     &w.site.Meta,
 			Nav:      &w.site.Nav,


### PR DESCRIPTION
For issue #192 