### PR TITLE
Extend tags to also have .Href for clickable tags.

### DIFF
--- a/example/content/blog/making-barista-quality-espresso.md
+++ b/example/content/blog/making-barista-quality-espresso.md
@@ -8,7 +8,7 @@ Tags:
 Img: /static/img/espresso.jpg
 Related:
     - /blog/steaming-milk-for-cappuccino
-Credit: Burst on Pexels
+Credit: Burst on Pexels 
 ---
 
 Do you enjoy a high-quality italian Espresso as much as I do? Quite frankly,

--- a/example/themes/default/templates/list-page.html
+++ b/example/themes/default/templates/list-page.html
@@ -15,6 +15,9 @@
                     <p>{{$page.Description}}</p>
                     <p><a href="{{$page.Href}}">read post</a></p>
                 </div>
+                {{range $tag := $page.Tags}}
+                    <a href={{$tag.Href}}>{{$tag}}</a>
+                {{end}}
             {{end}}
         </main>
     </body>

--- a/example/themes/default/templates/list-page.html
+++ b/example/themes/default/templates/list-page.html
@@ -15,9 +15,12 @@
                     <p>{{$page.Description}}</p>
                     <p><a href="{{$page.Href}}">read post</a></p>
                 </div>
-                {{range $tag := $page.Tags}}
-                    <a href={{$tag.Href}}>{{$tag}}</a>
-                {{end}}
+                <p>
+                    Tags:
+                    {{range $tag := $page.Tags}}
+                        <a href={{$tag.Href}}>{{$tag}}</a>
+                    {{end}}
+                </p>
             {{end}}
         </main>
     </body>

--- a/example/themes/default/templates/page.html
+++ b/example/themes/default/templates/page.html
@@ -21,6 +21,9 @@
             {{end}}
 
             {{.Page.Content}}
+            {{range $tag := .Page.Tags}}
+                <a href={{$tag.Href}}>{{$tag}}</a>
+            {{end}}
         </main>
         <aside>
             <h4>Related</h4>

--- a/example/themes/default/templates/startpage.html
+++ b/example/themes/default/templates/startpage.html
@@ -28,6 +28,12 @@
                     <h3>{{$page.Title}}</h3>
                     <p><small>Posted on {{$page.Date.Format "Jan 2 2006"}}</small></p>
                     <p>{{$page.Description}}</p>
+                    <p>
+                        Tags:
+                        {{range $tag := $page.Tags}}
+                            <a href={{$tag.Href}}>{{$tag}}</a>
+                        {{end}}
+                    </p>
                     <p><a href="{{$page.Href}}">read post</a></p>
                 </div>
             {{end}}

--- a/example/verless.yml
+++ b/example/verless.yml
@@ -23,11 +23,12 @@ site:
 plugins:
   - atom
   - related
+  - tags
 # Specify your theme.
 theme: default
 build:
   before:
-    # - If you need to run a command before the build, add it here.
+  # - If you need to run a command before the build, add it here.
   # Automatically overwrite the output directory without having
   # to specify the --overwrite flag each time.
   overwrite: true

--- a/model/page.go
+++ b/model/page.go
@@ -6,11 +6,15 @@ const (
 	customListPageID string = "index"
 )
 
+// Tag is used for grouping pages with similar content.
 type Tag struct {
 	Name string
 	Href string
 }
 
+// String implements the Stringer interface and allows
+// accessing the name field directly in templates without calling .Name
+// which preserves backwards compatibility with older versions.
 func (t Tag) String() string {
 	return t.Name
 }

--- a/model/page.go
+++ b/model/page.go
@@ -6,6 +6,15 @@ const (
 	customListPageID string = "index"
 )
 
+type Tag struct {
+	Name string
+	Href string
+}
+
+func (t Tag) String() string {
+	return t.Name
+}
+
 // Page represents a sub-page of the website.
 type Page struct {
 	Route       string
@@ -14,7 +23,7 @@ type Page struct {
 	Title       string
 	Author      string
 	Date        time.Time
-	Tags        []string
+	Tags        []Tag
 	Img         string
 	Credit      string
 	Description string

--- a/parser/markdown_test.go
+++ b/parser/markdown_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/verless/verless/model"
 	"github.com/verless/verless/test"
 )
 
@@ -15,7 +16,7 @@ func TestMarkdown_ParsePage(t *testing.T) {
 		src     string
 		title   string
 		date    time.Time
-		tags    []string
+		tags    []model.Tag
 		content string
 	}{
 		{
@@ -28,9 +29,18 @@ Tags:
 ---
 
 This is a blog post.`,
-			title:   "Coffee Roasting Basics",
-			date:    time.Time{},
-			tags:    []string{"Coffee", "Roasting"},
+			title: "Coffee Roasting Basics",
+			date:  time.Time{},
+			tags: []model.Tag{
+				{
+					Name: "Coffee",
+					Href: "/tags/coffee",
+				},
+				{
+					Name: "Roasting",
+					Href: "/tags/roasting",
+				},
+			},
 			content: "<p>This is a blog post.</p>\n",
 		},
 	}

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -51,9 +51,10 @@ func readMetadata(metadata metadata, page *model.Page) {
 	})
 
 	readList(metadata["Tags"], func(val interface{}) {
+		name := val.(string)
 		page.Tags = append(page.Tags, model.Tag{
-			Name: val.(string),
-			Href: "/tags/" + strings.ToLower(val.(string)),
+			Name: name,
+			Href: "/tags/" + strings.ToLower(name),
 		})
 	})
 

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"time"
 
 	"github.com/verless/verless/model"
@@ -50,7 +51,10 @@ func readMetadata(metadata metadata, page *model.Page) {
 	})
 
 	readList(metadata["Tags"], func(val interface{}) {
-		page.Tags = append(page.Tags, val.(string))
+		page.Tags = append(page.Tags, model.Tag{
+			Name: val.(string),
+			Href: "/tags/" + strings.ToLower(val.(string)),
+		})
 	})
 
 	readPrimitive(metadata["Img"], func(val interface{}) {

--- a/plugin/tags/tags.go
+++ b/plugin/tags/tags.go
@@ -35,13 +35,13 @@ type tags struct {
 func (t *tags) ProcessPage(page *model.Page) error {
 	for _, tag := range page.Tags {
 		//sanitizing the tags like "Making Coffee" to "making-coffee"
-		tag = strings.Replace(tag, " ", "-", -1)
-		tag = strings.ToLower(tag)
+		tag.Name = strings.Replace(tag.Name, " ", "-", -1)
+		tag.Name = strings.ToLower(tag.Name)
 
-		if _, exists := t.m[tag]; !exists {
-			t.createListPage(tag)
+		if _, exists := t.m[tag.Name]; !exists {
+			t.createListPage(tag.Name)
 		}
-		t.m[tag].Pages = append(t.m[tag].Pages, page)
+		t.m[tag.Name].Pages = append(t.m[tag.Name].Pages, page)
 	}
 
 	return nil

--- a/plugin/tags/tags_test.go
+++ b/plugin/tags/tags_test.go
@@ -10,10 +10,21 @@ import (
 var (
 	// testPages is a set of pages used for testing.
 	testPages = []model.Page{
-		{ID: "page-0", Route: "/route-0", Tags: []string{"t-1", "t-2"}},
-		{ID: "page-1", Route: "/route-1", Tags: []string{"t-1", "t-3"}},
-		{ID: "page-2", Route: "/route-2", Tags: []string{"t-2", "t-3"}},
-		{ID: "page-3", Route: "/route-3", Tags: []string{"t-2"}},
+		{ID: "page-0", Route: "/route-0", Tags: []model.Tag{
+			{Name: "t-1", Href: "/tags/t-1"},
+			{Name: "t-2", Href: "/tags/t-2"},
+		}},
+		{ID: "page-1", Route: "/route-1", Tags: []model.Tag{
+			{Name: "t-1", Href: "/tags/t-1"},
+			{Name: "t-3", Href: "/tags/t-3"},
+		}},
+		{ID: "page-2", Route: "/route-2", Tags: []model.Tag{
+			{Name: "t-2", Href: "/tags/t-2"},
+			{Name: "t-3", Href: "/tags/t-3"},
+		}},
+		{ID: "page-3", Route: "/route-3", Tags: []model.Tag{
+			{Name: "t-2", Href: "/tags/t-2"},
+		}},
 	}
 )
 
@@ -42,11 +53,11 @@ func TestTags_ProcessPage(t *testing.T) {
 			}
 
 			for _, tag := range page.Tags {
-				taggerTag, exists := tagger.m[tag]
+				taggerTag, exists := tagger.m[tag.Name]
 
 				test.Assert(t, exists, "tag should exist")
 				test.NotEquals(t, nil, taggerTag)
-				test.Assert(t, len(tagger.m[tag].Pages) > 0, "tag should exist")
+				test.Assert(t, len(tagger.m[tag.Name].Pages) > 0, "tag should exist")
 			}
 		}
 	}


### PR DESCRIPTION
This fixes that a manually built link does not work with tags containing uppercase chars.

Closes #232