### PR TITLE
Make ProcessPage of the plugins safe for concurrent usage.

### DIFF
--- a/core/build.go
+++ b/core/build.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// parallelism specifies the number of parallel workers.
+	// parallelism specifies the number of parallel workers
 	parallelism int = 4
 )
 
@@ -172,8 +172,7 @@ func (b *Build) Run() error {
 		}
 	}()
 
-	err := b.preProcessing()
-	if err != nil {
+	if err := b.preProcessing(); err != nil {
 		return err
 	}
 
@@ -212,13 +211,11 @@ func (b *Build) Run() error {
 		return fmt.Errorf("errors while processing files: %v", collectedErrors)
 	}
 
-	err = b.postProcessing()
-	if err != nil {
+	if err := b.postProcessing(); err != nil {
 		return err
 	}
 
-	err = b.render()
-	if err != nil {
+	if err := b.render(); err != nil {
 		return err
 	}
 

--- a/core/build.go
+++ b/core/build.go
@@ -217,6 +217,15 @@ func (b *Build) Run() error {
 		return err
 	}
 
+	err = b.render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Build) render() error {
 	site, err := b.Builder.Dispatch()
 	if err != nil {
 		return err

--- a/core/build.go
+++ b/core/build.go
@@ -172,6 +172,17 @@ func (b *Build) Run() error {
 		}
 	}()
 
+	for _, p := range b.Plugins {
+		prePostPlugin, ok := p.(plugin.PrePostProcessPlugin)
+		if !ok {
+			continue
+		}
+
+		if err := prePostPlugin.PreProcessPages(); err != nil {
+			return err
+		}
+	}
+
 	wg := sync.WaitGroup{}
 	wg.Add(parallelism)
 
@@ -205,6 +216,17 @@ func (b *Build) Run() error {
 
 	if len(collectedErrors) > 0 {
 		return fmt.Errorf("errors while processing files: %v", collectedErrors)
+	}
+
+	for _, p := range b.Plugins {
+		prePostPlugin, ok := p.(plugin.PrePostProcessPlugin)
+		if !ok {
+			continue
+		}
+
+		if err := prePostPlugin.PostProcessPages(); err != nil {
+			return err
+		}
 	}
 
 	site, err := b.Builder.Dispatch()

--- a/plugin/atom/atom.go
+++ b/plugin/atom/atom.go
@@ -4,7 +4,6 @@ package atom
 import (
 	"fmt"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/gorilla/feeds"
@@ -35,6 +34,8 @@ func New(meta *model.Meta, fs afero.Fs, outputDir string) *atom {
 		outputDir: outputDir,
 	}
 
+	a.feedItems = make(chan *feeds.Item)
+
 	return &a
 }
 
@@ -43,9 +44,49 @@ func New(meta *model.Meta, fs afero.Fs, outputDir string) *atom {
 type atom struct {
 	meta      *model.Meta
 	feed      *feeds.Feed
-	feedMutex sync.RWMutex
+	feedItems chan *feeds.Item
 	fs        afero.Fs
 	outputDir string
+
+	// workerShouldStop is a channel which indicates that the worker should stop working.
+	// To stop it, pass true to it. The worker will close the channel.
+	workerShouldStop chan bool
+	// workerFinishedSignal gets closed by the worker to indicate that it finished all it's work.
+	workerFinishedSignal chan bool
+}
+
+// PreProcessPages starts a worker goroutine which handles the a.feed.Add.
+// This improves speed as the ProcessPage can add new items in a non blocking way.
+func (a *atom) PreProcessPages() error {
+	a.workerShouldStop = make(chan bool)
+	a.workerFinishedSignal = make(chan bool)
+
+	go func() {
+		defer func() {
+			close(a.workerShouldStop)
+			fmt.Println("do end")
+			close(a.workerFinishedSignal)
+			fmt.Println("did end")
+		}()
+
+		for {
+			select {
+			case shouldStop := <-a.workerShouldStop:
+				if shouldStop {
+					return
+				}
+			default:
+			}
+
+			select {
+			case feedItem := <-a.feedItems:
+				a.feed.Add(feedItem)
+			default:
+			}
+		}
+	}()
+
+	return nil
 }
 
 // ProcessPage takes a page to be processed by the plugin, reads
@@ -65,9 +106,18 @@ func (a *atom) ProcessPage(page *model.Page) error {
 		Created:     page.Date,
 	}
 
-	a.feedMutex.Lock()
-	a.feed.Add(item)
-	a.feedMutex.Unlock()
+	a.feedItems <- item
+	return nil
+}
+
+// PostProcessPages stops and waits for the worker from PreProcessPages to finish.
+func (a *atom) PostProcessPages() error {
+	if a.workerShouldStop != nil {
+		a.workerShouldStop <- true
+	}
+	fmt.Println("wait end")
+	_, _ = <-a.workerFinishedSignal
+	fmt.Println("end")
 	return nil
 }
 

--- a/plugin/atom/atom.go
+++ b/plugin/atom/atom.go
@@ -64,9 +64,7 @@ func (a *atom) PreProcessPages() error {
 	go func() {
 		defer func() {
 			close(a.workerShouldStop)
-			fmt.Println("do end")
 			close(a.workerFinishedSignal)
-			fmt.Println("did end")
 		}()
 
 		for {
@@ -115,9 +113,7 @@ func (a *atom) PostProcessPages() error {
 	if a.workerShouldStop != nil {
 		a.workerShouldStop <- true
 	}
-	fmt.Println("wait end")
 	_, _ = <-a.workerFinishedSignal
-	fmt.Println("end")
 	return nil
 }
 

--- a/plugin/atom/atom.go
+++ b/plugin/atom/atom.go
@@ -4,6 +4,7 @@ package atom
 import (
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/gorilla/feeds"
@@ -42,6 +43,7 @@ func New(meta *model.Meta, fs afero.Fs, outputDir string) *atom {
 type atom struct {
 	meta      *model.Meta
 	feed      *feeds.Feed
+	feedMutex sync.RWMutex
 	fs        afero.Fs
 	outputDir string
 }
@@ -63,7 +65,9 @@ func (a *atom) ProcessPage(page *model.Page) error {
 		Created:     page.Date,
 	}
 
+	a.feedMutex.Lock()
 	a.feed.Add(item)
+	a.feedMutex.Unlock()
 	return nil
 }
 

--- a/plugin/atom/atom_test.go
+++ b/plugin/atom/atom_test.go
@@ -38,6 +38,13 @@ func TestAtom_ProcessPage(t *testing.T) {
 			Base: "https://example.com",
 		}, afero.NewOsFs(), "")
 
+		// Note that hte ProcessPage functionality is heavily coupled with the Pre/Post methods.
+		// That's why we have to call it here also.
+		err := a.PreProcessPages()
+		if test.ExpectedError(t, nil, err) != test.IsCorrectNil {
+			return
+		}
+
 		for i, page := range testCase.pages {
 			t.Logf("process page number %v, route '%v'", i, page.Route)
 			err := a.ProcessPage(&page)
@@ -50,6 +57,11 @@ func TestAtom_ProcessPage(t *testing.T) {
 
 			canonicalLink := fmt.Sprintf("%s%s/%s", a.meta.Base, page.Route, page.ID)
 			test.Equals(t, canonicalLink, item.Link.Href)
+		}
+
+		err = a.PostProcessPages()
+		if test.ExpectedError(t, nil, err) != test.IsCorrectNil {
+			return
 		}
 
 		test.Equals(t, len(testCase.pages), len(a.feed.Items))

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -20,6 +20,17 @@ type Plugin interface {
 	PostWrite() error
 }
 
+type PrePostProcessPlugin interface {
+	Plugin
+
+	// PreProcessPages will be invoked before all pages get processed.
+	// So this will be called only once.
+	PreProcessPages() error
+	// PostProcessPages will be invoked after all pages were processed.
+	// So this will be called only once.
+	PostProcessPages() error
+}
+
 // LoadAll returns a map of all available plugins. Each entry
 // is a function that returns a fully initialized plugin instance.
 func LoadAll(cfg *config.Config, fs afero.Fs, outputDir string) map[string]func() Plugin {

--- a/plugin/related/related.go
+++ b/plugin/related/related.go
@@ -2,12 +2,15 @@
 package related
 
 import (
+	"sync"
+
 	"github.com/verless/verless/model"
 	"github.com/verless/verless/tree"
 )
 
 type related struct {
-	pages map[string]*model.Page
+	pages      map[string]*model.Page
+	pagesMutex sync.RWMutex
 }
 
 // New initializes and returns a related plugin instance.
@@ -20,7 +23,9 @@ func New() *related {
 // ProcessPage adds a given pointer to a Page instance to the plugin's page
 // map. This prevents that each page has to be resolved from the tre later.
 func (r *related) ProcessPage(page *model.Page) error {
+	r.pagesMutex.Lock()
 	r.pages[page.Href] = page
+	r.pagesMutex.Unlock()
 	return nil
 }
 

--- a/plugin/tags/tags.go
+++ b/plugin/tags/tags.go
@@ -29,7 +29,7 @@ func New() *tags {
 // tags from all processed pages.
 type tags struct {
 	tags      map[string]*model.ListPage
-	tagsMutex sync.RWMutex
+	tagsMutex sync.Mutex
 }
 
 // ProcessPage creates a new map entry for each tag in the processed
@@ -40,15 +40,13 @@ func (t *tags) ProcessPage(page *model.Page) error {
 		tag.Name = strings.Replace(tag.Name, " ", "-", -1)
 		tag.Name = strings.ToLower(tag.Name)
 
-		t.tagsMutex.RLock()
+		t.tagsMutex.Lock()
 		_, tagExists := t.tags[tag.Name]
-		t.tagsMutex.RUnlock()
 
 		if !tagExists {
 			t.createListPage(tag.Name)
 		}
 
-		t.tagsMutex.Lock()
 		t.tags[tag.Name].Pages = append(t.tags[tag.Name].Pages, page)
 		t.tagsMutex.Unlock()
 	}

--- a/plugin/tags/tags_test.go
+++ b/plugin/tags/tags_test.go
@@ -42,11 +42,11 @@ func TestTags_ProcessPage(t *testing.T) {
 			}
 
 			for _, tag := range page.Tags {
-				taggerTag, exists := tagger.m[tag]
+				taggerTag, exists := tagger.tags[tag]
 
 				test.Assert(t, exists, "tag should exist")
 				test.NotEquals(t, nil, taggerTag)
-				test.Assert(t, len(tagger.m[tag].Pages) > 0, "tag should exist")
+				test.Assert(t, len(tagger.tags[tag].Pages) > 0, "tag should exist")
 			}
 		}
 	}
@@ -72,7 +72,7 @@ func TestTags_PreWrite(t *testing.T) {
 		t.Log(name)
 
 		tagger := New()
-		tagger.m = testCase.tagsListPages
+		tagger.tags = testCase.tagsListPages
 		s := model.NewSite()
 		err := tagger.PreWrite(&s)
 		if test.ExpectedError(t, testCase.expectedError, err) != test.IsCorrectNil {
@@ -83,7 +83,7 @@ func TestTags_PreWrite(t *testing.T) {
 		test.Equals(t, true, ok)
 		test.NotEquals(t, nil, tags)
 
-		for tag := range tagger.m {
+		for tag := range tagger.tags {
 			child, ok := tags.Children()[tag]
 			test.Equals(t, true, ok)
 			test.NotEquals(t, nil, child)


### PR DESCRIPTION
As the pipeline for the last Merge failed:
https://github.com/verless/verless/commit/ee4f6ec44e9b800aed6ca4e5d89b33e8e6bfe631

I noticed that the plugins were not written concurrency-safe.


This PR should fix that, but Maybe we should write some test for it somehow?
Also it slows down the processing dramatically. Any idea for this?