### PR TITLE
Add support for template inheritance #231

### DIFF
--- a/theme/theme.go
+++ b/theme/theme.go
@@ -26,6 +26,7 @@ const (
 	Default          string = "default"
 	PageTemplate     string = "page.html"
 	ListPageTemplate string = "list-page.html"
+	TemplateBase     string = "base"
 	configFilename   string = "theme"
 )
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -151,9 +151,11 @@ func (w *writer) loadTemplate(t *model.Type, defaultTpl string) (*template.Templ
 		return tpl.Get(pageTpl)
 	}
 
-	tplPath := filepath.Join(theme.TemplatePath(w.ctx.Path, w.ctx.Theme), pageTpl)
+	templatesRoot := filepath.Join(theme.TemplatePath(w.ctx.Path, w.ctx.Theme))
+	tplPath := filepath.Join(templatesRoot, pageTpl)
+	basePath := filepath.Join(templatesRoot, theme.TemplateBase)
 
-	return tpl.Register(pageTpl, tplPath, w.ctx.RecompileTemplates)
+	return tpl.Register(pageTpl, tplPath, basePath, w.ctx.RecompileTemplates)
 }
 
 func (w *writer) copyDirs() error {


### PR DESCRIPTION
I implemented support for template inheritance. 

It works as follows:

- a `base` directory may be added to the `templates`directory of any theme. 
- if this is available, template sets will be parsed for the list page and the pages, which include the files in `base`. This way, the "not defined" error mentioned in the issue #231 is fixed.
- if `base` is not available, everything works as before.

Of course I'd also be open for changing the name `base` to something different.
Can you please review the code? Thanks :)