### PR TITLE
Fix creating files with wrong access permissions

### DIFF
--- a/core/create.go
+++ b/core/create.go
@@ -151,7 +151,7 @@ Date: %s
 `
 
 	content := fmt.Sprintf(defaultContentTemplate, time.Now().Format("2006-01-02"))
-	if err := ioutil.WriteFile(contentPath, []byte(content), 0755); err != nil {
+	if err := ioutil.WriteFile(contentPath, []byte(content), 0644); err != nil {
 		return err
 	}
 
@@ -161,7 +161,7 @@ Date: %s
 
 func createFiles(files map[string][]byte) error {
 	for path, content := range files {
-		if err := ioutil.WriteFile(path, content, 0755); err != nil {
+		if err := ioutil.WriteFile(path, content, 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Files are created globally with wrong permissions.

> The **755** sets permissions so that, User/owner can read, can write and can execute. Group can read, can't write and can execute. Others can read, can't write and can execute.

For directories it's fine but allowing a file to have execute permissions may allow a security hole to be exploited by malware or by malicious users.

Setting them to **644** makes much more logical sense.